### PR TITLE
Change to repo directory in workflow

### DIFF
--- a/.github/workflows/update_events.yml
+++ b/.github/workflows/update_events.yml
@@ -19,6 +19,8 @@ jobs:
         run: pip install --no-cache-dir -r requirements.txt
       - name: Run script
         run: python .scripts/events_updater.py
+      - name: Change to repo directory
+        run: cd $GITHUB_WORKSPACE
       - name: Set up Git
         run: |
           git config user.name "GitHub Actions"


### PR DESCRIPTION
This pull request adds a step to the workflow that changes the current directory to the repository directory. This is necessary for subsequent commands to run in the correct directory.