### PR TITLE
Update events in GitHub Actions workflow

### DIFF
--- a/.github/workflows/update_events.yml
+++ b/.github/workflows/update_events.yml
@@ -19,11 +19,9 @@ jobs:
         run: pip install --no-cache-dir -r requirements.txt
       - name: Run script
         run: python .scripts/events_updater.py
-      - name: Change ownership of repository directory
-        run: sudo chown -R $(whoami) ${{ github.workspace }}
       - name: Commit and push changes
-        uses: EndBug/add-and-commit@v7
+        uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          author_name: "GitHub Actions"
-          author_email: "github-actions@github.com"
-          message: "[Auto] Update events"
+          commit_message: "[Auto] Update events"
+          commit_user_name: "GitHub Actions"
+          commit_user_email: "github-actions@github.com"


### PR DESCRIPTION
Previously, the GitHub Actions workflow was using the "EndBug/add-and-commit" action to commit and push changes. This PR updates the workflow to use the "stefanzweifel/git-auto-commit-action" action instead. This change ensures that events are properly updated in the workflow.